### PR TITLE
Update README.md

### DIFF
--- a/labs/lab03/README.md
+++ b/labs/lab03/README.md
@@ -168,7 +168,7 @@ Alternatively, use PowerShell to automate user creation as follows:
 
 ```powershell
 # Create Provost
-New-ADUser -Name "Provost" -GivenName "University" -Surname "Provost" -UserPrincipalName "provost@university.local" -Path "OU=Provost,OU=University,DC=university,DC=local" -AccountPassword (ConvertTo-SecureString "Password123!" -AsPlainText -Force) -Enabled $true
+New-ADUser -Name "Provost" -GivenName "University" -Surname "Provost" -UserPrincipalName "provost@university.local" -Path "OU=University,DC=university,DC=local" -AccountPassword (ConvertTo-SecureString "Password123!" -AsPlainText -Force) -Enabled $true
 
 # Department Chairs
 $departments = @("ComputerScience", "Mathematics", "Engineering")


### PR DESCRIPTION
The old version of this line of code was trying to place the Provost user into an OU called "Provost", but at this point in the lab, there IS no OU called Provost! The old code generated an "ADIdentityNotFoundException" because the Path was wrong.

I've run this edited version on my own VM, and it places the Provost user in the "University" OU, right where it belongs. 

I believe this was a human error, trying to fill in the metaphorical "$department" field of all the commands in the code block, but forgetting that the university provost does not belong to a department.